### PR TITLE
Implement custom script in smtp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker-entrypoint.d/100-execute-custom-scripts.sh
+++ b/docker-entrypoint.d/100-execute-custom-scripts.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Executing custom scripts located in CUSTOM_SCRIPTS_DIRECTORY if environment variable is set
+if [[ -z "${CUSTOM_SCRIPTS_DIRECTORY}" ]]; then
+  echo "[INFO] No CUSTOM_SCRIPTS_DIRECTORY env variable set"
+else
+  echo "[INFO] CUSTOM_SCRIPTS_DIRECTORY env variable set to ${CUSTOM_SCRIPTS_DIRECTORY}"
+  # Regex is needed in jetty9 images, but not alpine's ones.
+  run-parts -v "${CUSTOM_SCRIPTS_DIRECTORY}" --regex='.*'
+  echo "[INFO] End executing custom scripts"
+fi


### PR DESCRIPTION
# Custom scripts 

This PR adds the capability to run scripts at startup of the container.

It's a part of the georchestra PR :
- https://github.com/georchestra/georchestra/pull/4083

Soving issue : 
- https://github.com/georchestra/georchestra/issues/4030

## How-to

Set  `CUSTOM_SCRIPTS_DIRECTORY` environment variable to point to a valid volume.
Set a volume with scripts to execute.


Example :
```
 smtp:
    ...
    volumes:
      - georchestra_datadir:/etc/georchestra
    environment:
      - CUSTOM_SCRIPTS_DIRECTORY=/etc/georchestra/smtp/scripts
```